### PR TITLE
fix: include buffer metadata in glb output

### DIFF
--- a/lib/gltf/gltf-builder.ts
+++ b/lib/gltf/gltf-builder.ts
@@ -674,20 +674,27 @@ export class GLTFBuilder {
     const bufferData = this.bufferBuilder.getBuffer()
 
     if (binary) {
-      // Create GLB
-      return this.createGLB(this.gltf, bufferData)
-    } else {
-      // Create GLTF with embedded buffer
+      // Include buffer reference for GLB
       this.gltf.buffers = [
         {
           byteLength: bufferData.byteLength,
-          uri: `data:application/octet-stream;base64,${this.arrayBufferToBase64(
-            bufferData,
-          )}`,
         },
       ]
-      return this.gltf
+
+      // Create GLB
+      return this.createGLB(this.gltf, bufferData)
     }
+
+    // Create GLTF with embedded buffer
+    this.gltf.buffers = [
+      {
+        byteLength: bufferData.byteLength,
+        uri: `data:application/octet-stream;base64,${this.arrayBufferToBase64(
+          bufferData,
+        )}`,
+      },
+    ]
+    return this.gltf
   }
 
   private createGLB(gltf: GLTF, bufferData: ArrayBuffer): ArrayBuffer {

--- a/tests/integration/circuit-to-gltf.test.ts
+++ b/tests/integration/circuit-to-gltf.test.ts
@@ -30,7 +30,19 @@ test("convertCircuitJsonToGltf should convert circuit to GLB", async () => {
 
   // GLB format returns an ArrayBuffer
   expect(result).toBeInstanceOf(ArrayBuffer)
-  expect((result as ArrayBuffer).byteLength).toBeGreaterThan(0)
+  const arrayBuffer = result as ArrayBuffer
+  expect(arrayBuffer.byteLength).toBeGreaterThan(0)
+
+  // Parse JSON chunk to ensure buffer reference exists
+  const view = new DataView(arrayBuffer)
+  const jsonChunkLength = view.getUint32(12, true)
+  const jsonBytes = new Uint8Array(arrayBuffer, 20, jsonChunkLength)
+  const jsonText = new TextDecoder().decode(jsonBytes).replace(/\u0000+$/, "")
+  const gltf = JSON.parse(jsonText)
+
+  expect(Array.isArray(gltf.buffers)).toBe(true)
+  expect(gltf.buffers.length).toBe(1)
+  expect(gltf.buffers[0].byteLength).toBeGreaterThan(0)
 })
 
 test("convertCircuitJsonTo3D should create 3D scene", async () => {


### PR DESCRIPTION
## Summary
- include buffer array when generating GLB files
- verify GLB output contains embedded buffer metadata

## Testing
- `bun test tests/integration/circuit-to-gltf.test.ts` *(fails: recursive use of an object detected which would lead to unsafe aliasing in rust)*

------
https://chatgpt.com/codex/tasks/task_b_68c0fec9605c832e9af69ec249a3d052