### PR TITLE
Mark resvg-js peer dependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
   "peerDependenciesMeta": {
     "@resvg/resvg-wasm": {
       "optional": true
+    },
+    "@resvg/resvg-js": {
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- mark @resvg/resvg-js as an optional peer dependency alongside @resvg/resvg-wasm

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e20b73c788832e924ae9ee50e6bac5