### PR TITLE
feat: build pcb board geometry with jscad

### DIFF
--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -1,4 +1,9 @@
-import { type CircuitJson, type CadComponent } from "circuit-json"
+import {
+  type CircuitJson,
+  type CadComponent,
+  type PcbHole,
+  type PCBPlatedHole,
+} from "circuit-json"
 import { cju } from "@tscircuit/circuit-json-util"
 import type {
   Box3D,
@@ -13,6 +18,7 @@ import { loadGLB } from "../loaders/glb"
 import { loadGLTF } from "../loaders/gltf"
 import { renderBoardTextures } from "./board-renderer"
 import { COORDINATE_TRANSFORMS } from "../utils/coordinate-transform"
+import { createBoardMesh } from "../utils/pcb-board-geometry"
 
 const DEFAULT_BOARD_THICKNESS = 1.6 // mm
 const DEFAULT_COMPONENT_HEIGHT = 2 // mm
@@ -53,6 +59,20 @@ export async function convertCircuitJsonTo3D(
   }
 
   // Create the main PCB board box
+  const effectiveBoardThickness = pcbBoard.thickness ?? boardThickness
+
+  const pcbHoles = (db.pcb_hole?.list?.() ?? []) as PcbHole[]
+  const pcbPlatedHoles = (db.pcb_plated_hole?.list?.() ?? []) as PCBPlatedHole[]
+
+  const boardMesh = createBoardMesh(pcbBoard, {
+    thickness: effectiveBoardThickness,
+    holes: pcbHoles,
+    platedHoles: pcbPlatedHoles,
+  })
+
+  const meshWidth = boardMesh.boundingBox.max.x - boardMesh.boundingBox.min.x
+  const meshHeight = boardMesh.boundingBox.max.z - boardMesh.boundingBox.min.z
+
   const boardBox: Box3D = {
     center: {
       x: pcbBoard.center.x,
@@ -60,10 +80,12 @@ export async function convertCircuitJsonTo3D(
       z: pcbBoard.center.y,
     },
     size: {
-      x: pcbBoard.width,
-      y: boardThickness,
-      z: pcbBoard.height,
+      x: Number.isFinite(meshWidth) ? meshWidth : pcbBoard.width,
+      y: effectiveBoardThickness,
+      z: Number.isFinite(meshHeight) ? meshHeight : pcbBoard.height,
     },
+    mesh: boardMesh,
+    color: pcbColor,
   }
 
   // Render board textures if requested and resolution > 0
@@ -132,8 +154,8 @@ export async function convertCircuitJsonTo3D(
       : {
           x: pcbComponent?.center.x ?? 0,
           y: isBottomLayer
-            ? -(boardThickness / 2 + size.y / 2)
-            : boardThickness / 2 + size.y / 2,
+            ? -(effectiveBoardThickness / 2 + size.y / 2)
+            : effectiveBoardThickness / 2 + size.y / 2,
           z: pcbComponent?.center.y ?? 0,
         }
 
@@ -233,8 +255,8 @@ export async function convertCircuitJsonTo3D(
       center: {
         x: component.center.x,
         y: isBottomLayer
-          ? -(boardThickness / 2 + compHeight / 2)
-          : boardThickness / 2 + compHeight / 2,
+          ? -(effectiveBoardThickness / 2 + compHeight / 2)
+          : effectiveBoardThickness / 2 + compHeight / 2,
         z: component.center.y,
       },
       size: {

--- a/lib/gltf/gltf-builder.ts
+++ b/lib/gltf/gltf-builder.ts
@@ -86,7 +86,7 @@ export class GLTFBuilder {
     defaultMaterialIndex: number,
   ): Promise<void> {
     // If we have face-specific textures or need green sides, use face-based approach
-    if (box.texture && (box.texture.top || box.texture.bottom)) {
+    if (!box.mesh && box.texture && (box.texture.top || box.texture.bottom)) {
       await this.addBoxWithFaceMaterials(box, defaultMaterialIndex)
       return
     }

--- a/lib/utils/pcb-board-geometry.ts
+++ b/lib/utils/pcb-board-geometry.ts
@@ -1,0 +1,254 @@
+import { extrudeLinear } from "@jscad/modeling/src/operations/extrusions"
+import {
+  polygon,
+  rectangle,
+  roundedRectangle,
+  cylinder,
+} from "@jscad/modeling/src/primitives"
+import {
+  translate,
+  rotateZ,
+  rotateX,
+} from "@jscad/modeling/src/operations/transforms"
+import { subtract } from "@jscad/modeling/src/operations/booleans"
+import * as geom3 from "@jscad/modeling/src/geometries/geom3"
+import measureBoundingBox from "@jscad/modeling/src/measurements/measureBoundingBox"
+import type { Geom3 } from "@jscad/modeling/src/geometries/types"
+import type { Vec2 } from "@jscad/modeling/src/maths/types"
+import type { PcbBoard, PcbHole, PCBPlatedHole, Point } from "circuit-json"
+import type { BoundingBox, STLMesh, Triangle } from "../types"
+
+const DEFAULT_SEGMENTS = 64
+const RADIUS_EPSILON = 1e-4
+
+export interface BoardGeometryOptions {
+  thickness: number
+  holes?: PcbHole[]
+  platedHoles?: PCBPlatedHole[]
+}
+
+const toVec2 = (point: Point, center: { x: number; y: number }): Vec2 => [
+  point.x - center.x,
+  point.y - center.y,
+]
+
+export const arePointsClockwise = (points: Vec2[]): boolean => {
+  let area = 0
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length
+    area += points[i]![0] * points[j]![1]
+    area -= points[j]![0] * points[i]![1]
+  }
+  const signedArea = area / 2
+  return signedArea <= 0
+}
+
+const getNumberProperty = (
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined => {
+  const value = obj[key]
+  return typeof value === "number" ? value : undefined
+}
+
+const createBoardOutlineGeom = (
+  board: PcbBoard,
+  center: { x: number; y: number },
+  thickness: number,
+): Geom3 => {
+  if (board.outline && board.outline.length >= 3) {
+    let outlinePoints: Vec2[] = board.outline.map((pt) => toVec2(pt, center))
+
+    if (arePointsClockwise(outlinePoints)) {
+      outlinePoints = outlinePoints.slice().reverse()
+    }
+
+    const shape2d = polygon({ points: outlinePoints })
+    let geom = extrudeLinear({ height: thickness }, shape2d)
+    geom = translate([0, 0, -thickness / 2], geom)
+    return geom
+  }
+
+  const baseRect = rectangle({ size: [board.width, board.height] })
+  let geom = extrudeLinear({ height: thickness }, baseRect)
+  geom = translate([0, 0, -thickness / 2], geom)
+  return geom
+}
+
+const createCircularHole = (
+  x: number,
+  y: number,
+  radius: number,
+  thickness: number,
+): Geom3 =>
+  cylinder({
+    center: [x, y, 0],
+    height: thickness + 1,
+    radius,
+    segments: DEFAULT_SEGMENTS,
+  })
+
+const createPillHole = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  thickness: number,
+  rotate: boolean,
+): Geom3 => {
+  const minDimension = Math.min(width, height)
+  const maxAllowedRadius = Math.max(0, minDimension / 2 - RADIUS_EPSILON)
+  const roundRadius =
+    maxAllowedRadius <= 0 ? 0 : Math.min(height / 2, maxAllowedRadius)
+  const hole2d = roundedRectangle({
+    size: [width, height],
+    roundRadius,
+    segments: DEFAULT_SEGMENTS,
+  })
+  let hole3d = extrudeLinear({ height: thickness + 1 }, hole2d)
+  hole3d = translate([0, 0, -(thickness + 1) / 2], hole3d)
+
+  if (rotate) {
+    hole3d = rotateZ(Math.PI / 2, hole3d)
+  }
+
+  return translate([x, y, 0], hole3d)
+}
+
+const createHoleGeoms = (
+  boardCenter: { x: number; y: number },
+  thickness: number,
+  holes: PcbHole[] = [],
+  platedHoles: PCBPlatedHole[] = [],
+): Geom3[] => {
+  const holeGeoms: Geom3[] = []
+
+  for (const hole of holes) {
+    const holeRecord = hole as unknown as Record<string, unknown>
+    const diameter =
+      getNumberProperty(holeRecord, "hole_diameter") ??
+      getNumberProperty(holeRecord, "diameter")
+    if (!diameter) continue
+
+    const radius = diameter / 2
+    const relX = hole.x - boardCenter.x
+    const relY = hole.y - boardCenter.y
+    holeGeoms.push(createCircularHole(relX, relY, radius, thickness))
+  }
+
+  for (const plated of platedHoles) {
+    const relX = plated.x - boardCenter.x
+    const relY = plated.y - boardCenter.y
+    const platedRecord = plated as unknown as Record<string, unknown>
+
+    if (plated.shape === "pill" || plated.shape === "pill_hole_with_rect_pad") {
+      const holeWidth =
+        getNumberProperty(platedRecord, "hole_width") ??
+        getNumberProperty(platedRecord, "outer_diameter") ??
+        0
+      const holeHeight =
+        getNumberProperty(platedRecord, "hole_height") ??
+        getNumberProperty(platedRecord, "hole_diameter") ??
+        0
+      if (!holeWidth || !holeHeight) continue
+      const rotate = holeHeight > holeWidth
+      const width = rotate ? holeHeight : holeWidth
+      const height = rotate ? holeWidth : holeHeight
+      holeGeoms.push(
+        createPillHole(relX, relY, width, height, thickness, rotate),
+      )
+      continue
+    }
+
+    const diameter =
+      getNumberProperty(platedRecord, "hole_diameter") ??
+      getNumberProperty(platedRecord, "outer_diameter")
+    if (!diameter) continue
+    holeGeoms.push(createCircularHole(relX, relY, diameter / 2, thickness))
+  }
+
+  return holeGeoms
+}
+
+const geom3ToTriangles = (geometry: Geom3, polygons?: any[]): Triangle[] => {
+  const sourcePolygons = polygons ?? geom3.toPolygons(geometry)
+  const triangles: Triangle[] = []
+
+  for (const poly of sourcePolygons) {
+    if (!poly || poly.vertices.length < 3) continue
+    const base = poly.vertices[0]!
+    const next = poly.vertices[1]!
+    const next2 = poly.vertices[2]!
+
+    const ab = [next[0]! - base[0]!, next[1]! - base[1]!, next[2]! - base[2]!]
+    const ac = [
+      next2[0]! - base[0]!,
+      next2[1]! - base[1]!,
+      next2[2]! - base[2]!,
+    ]
+    const cross = [
+      ab[1]! * ac[2]! - ab[2]! * ac[1]!,
+      ab[2]! * ac[0]! - ab[0]! * ac[2]!,
+      ab[0]! * ac[1]! - ab[1]! * ac[0]!,
+    ]
+    const length =
+      Math.sqrt(cross[0]! ** 2 + cross[1]! ** 2 + cross[2]! ** 2) || 1
+    const normal = {
+      x: cross[0]! / length,
+      y: cross[1]! / length,
+      z: cross[2]! / length,
+    }
+
+    for (let i = 1; i < poly.vertices.length - 1; i++) {
+      const v1 = poly.vertices[i]!
+      const v2 = poly.vertices[i + 1]!
+      const triangle: Triangle = {
+        vertices: [
+          { x: base[0]!, y: base[1]!, z: base[2]! },
+          { x: v1[0]!, y: v1[1]!, z: v1[2]! },
+          { x: v2[0]!, y: v2[1]!, z: v2[2]! },
+        ],
+        normal,
+      }
+      triangles.push(triangle)
+    }
+  }
+
+  return triangles
+}
+
+const createBoundingBox = (bbox: [number[], number[]]): BoundingBox => {
+  const [min, max] = bbox
+  return {
+    min: { x: min[0]!, y: min[1]!, z: min[2]! },
+    max: { x: max[0]!, y: max[1]!, z: max[2]! },
+  }
+}
+
+export const createBoardMesh = (
+  board: PcbBoard,
+  options: BoardGeometryOptions,
+): STLMesh => {
+  const { thickness, holes = [], platedHoles = [] } = options
+  const center = board.center ?? { x: 0, y: 0 }
+
+  let boardGeom = createBoardOutlineGeom(board, center, thickness)
+
+  const holeGeoms = createHoleGeoms(center, thickness, holes, platedHoles)
+  if (holeGeoms.length > 0) {
+    boardGeom = subtract(boardGeom, ...holeGeoms)
+  }
+
+  boardGeom = rotateX(-Math.PI / 2, boardGeom)
+
+  const polygons = geom3.toPolygons(boardGeom)
+  const triangles = geom3ToTriangles(boardGeom, polygons)
+
+  const bboxValues = measureBoundingBox(boardGeom)
+  const boundingBox = createBoundingBox(bboxValues)
+
+  return {
+    triangles,
+    boundingBox,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "@resvg/resvg-js": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "@jscad/modeling": "^2.12.6"
   }
 }

--- a/tests/unit/board-geometry.test.ts
+++ b/tests/unit/board-geometry.test.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "bun:test"
+import type {
+  CircuitJson,
+  PcbBoard,
+  PcbHole,
+  PCBPlatedHole,
+} from "circuit-json"
+import { createBoardMesh } from "../../lib/utils/pcb-board-geometry"
+import { convertCircuitJsonTo3D } from "../../lib/converters/circuit-to-3d"
+
+const triangleArea = (
+  a: { x: number; y: number; z: number },
+  b: { x: number; y: number; z: number },
+  c: { x: number; y: number; z: number },
+): number => {
+  const ab = { x: b.x - a.x, y: b.y - a.y, z: b.z - a.z }
+  const ac = { x: c.x - a.x, y: c.y - a.y, z: c.z - a.z }
+  const cross = {
+    x: ab.y * ac.z - ab.z * ac.y,
+    y: ab.z * ac.x - ab.x * ac.z,
+    z: ab.x * ac.y - ab.y * ac.x,
+  }
+  const magnitude = Math.sqrt(cross.x ** 2 + cross.y ** 2 + cross.z ** 2)
+  return 0.5 * magnitude
+}
+
+test("createBoardMesh subtracts drilled and plated holes", () => {
+  const drilledDiameter = 2
+  const platedHoleDiameter = 1.2
+
+  const board: PcbBoard = {
+    type: "pcb_board",
+    pcb_board_id: "board1",
+    center: { x: 10, y: 5 },
+    width: 20,
+    height: 10,
+    thickness: 1.6,
+    num_layers: 2,
+    material: "fr4",
+    outline: [
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+      { x: 20, y: 10 },
+      { x: 0, y: 10 },
+    ],
+  }
+
+  const holes: PcbHole[] = [
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole1",
+      x: 10,
+      y: 5,
+      hole_diameter: drilledDiameter,
+      hole_shape: "circle",
+    },
+  ]
+
+  const platedHoles: PCBPlatedHole[] = [
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph1",
+      x: 14,
+      y: 6,
+      hole_diameter: platedHoleDiameter,
+      outer_diameter: 2,
+      shape: "circle",
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const mesh = createBoardMesh(board, {
+    thickness: board.thickness ?? 1.6,
+    holes,
+    platedHoles,
+  })
+
+  expect(mesh.triangles.length).toBeGreaterThan(0)
+  expect(mesh.boundingBox.min.y).toBeCloseTo(-(board.thickness ?? 1.6) / 2, 6)
+  expect(mesh.boundingBox.max.y).toBeCloseTo((board.thickness ?? 1.6) / 2, 6)
+
+  const topArea = mesh.triangles
+    .filter((triangle) => triangle.normal.y > 0.9)
+    .reduce((sum, triangle) => {
+      const [a, b, c] = triangle.vertices
+      return sum + triangleArea(a, b, c)
+    }, 0)
+
+  const outlineArea = board.width * board.height
+  const drilledArea = Math.PI * (drilledDiameter / 2) ** 2
+  const platedArea = Math.PI * (platedHoleDiameter / 2) ** 2
+  const expectedArea = outlineArea - drilledArea - platedArea
+
+  expect(topArea).toBeCloseTo(expectedArea, 1)
+})
+
+test("convertCircuitJsonTo3D includes board mesh for outline boards", async () => {
+  const board: PcbBoard = {
+    type: "pcb_board",
+    pcb_board_id: "board_outline",
+    center: { x: 5, y: -5 },
+    width: 12,
+    height: 8,
+    thickness: 1.2,
+    num_layers: 2,
+    material: "fr4",
+    outline: [
+      { x: 0, y: -4 },
+      { x: 12, y: -4 },
+      { x: 12, y: 4 },
+      { x: 3, y: 4 },
+      { x: 0, y: 1 },
+    ],
+  }
+
+  const platedHoles: PCBPlatedHole[] = [
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "outline_via",
+      x: 6,
+      y: -1,
+      hole_diameter: 0.8,
+      outer_diameter: 1.4,
+      shape: "circle",
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const circuit: CircuitJson = [board, ...platedHoles]
+
+  const scene = await convertCircuitJsonTo3D(circuit, {
+    renderBoardTextures: false,
+  })
+
+  const boardBox = scene.boxes[0]!
+  expect(boardBox.mesh).toBeDefined()
+  expect(boardBox.mesh?.triangles.length ?? 0).toBeGreaterThan(0)
+  expect(boardBox.center).toEqual({
+    x: board.center.x,
+    y: 0,
+    z: board.center.y,
+  })
+  expect(boardBox.size.y).toBeCloseTo(board.thickness ?? 1.2, 6)
+})


### PR DESCRIPTION
## Summary
- build PCB board meshes with @jscad/modeling, including outline polygons plus circular and pill drill support
- hook the generated mesh into circuit-to-3d conversion while avoiding box-only texture rendering paths
- cover the new geometry with focused unit tests and add the @jscad/modeling dependency

## Testing
- bunx tsc --noEmit
- bun test tests/unit/board-geometry.test.ts
- bun test tests/board-texture-debug.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e47b9bb7cc832ebd9747eb493dfc5d