### PR TITLE
fix: adjust position and rotation values in usb-c-flashlight.json

### DIFF
--- a/site/assets/usb-c-flashlight.json
+++ b/site/assets/usb-c-flashlight.json
@@ -2470,12 +2470,12 @@
     "position": {
       "x": 0,
       "y": -12.78749940000003,
-      "z": 0.7
+      "z": 0
     },
     "rotation": {
       "x": 0,
-      "y": 180,
-      "z": 0
+      "y": 0,
+      "z": 180
     },
     "pcb_component_id": "pcb_component_0",
     "source_component_id": "source_component_0",


### PR DESCRIPTION
This pull request makes a minor adjustment to the `site/assets/usb-c-flashlight.json` file, updating the position and rotation values for a component. The change sets the `z` position to `0` and swaps the `y` and `z` rotation values, likely to correct the orientation of the component in the 3D model.

- Adjusted component position and rotation:
  - Set `z` position to `0` instead of `0.7`
  - Changed rotation from `{ y: 180, z: 0 }` to `{ y: 0, z: 180 }` to update the orientation
  (`[site/assets/usb-c-flashlight.jsonL2473-R2478](diffhunk://#diff-7dac50b65101a56519edc2d9314ea98a4c1cd8f6f1e5cd2d33b946e0000d1e09L2473-R2478)`)

## Before
<img width="569" height="415" alt="image" src="https://github.com/user-attachments/assets/5d1acea9-d265-4700-a1b7-fe50f58e178d" />

## After
<img width="569" height="415" alt="image" src="https://github.com/user-attachments/assets/6a7f5415-9fbd-4a1c-a6fc-62339449ccab" />
