### PR TITLE
Dynamically load resvg-wasm to fix the initWasm undefined error

### DIFF
--- a/lib/utils/svg-to-png-browser.ts
+++ b/lib/utils/svg-to-png-browser.ts
@@ -52,7 +52,8 @@ async function ensureWasmInitialized() {
         } catch {
           // Fallback to CDN - load the entire module from CDN
           try {
-            const cdnUrl = "https://esm.sh/@resvg/resvg-wasm@2.6.2"
+            const cdnUrl =
+              "https://cdn.jsdelivr.net/npm/@resvg/resvg-wasm@2.6.2/+esm"
             // @ts-ignore - Dynamic CDN import not recognized by TypeScript
             const resvgModule = await import(/* @vite-ignore */ cdnUrl)
             Resvg = resvgModule.Resvg


### PR DESCRIPTION
Fix: GLB export failing in browser when @resvg/resvg-wasm is externalized in Runframe

Problem
GLB export fails in RunFrameForCli (browser) with error:
`Failed to initialize WASM: TypeError: Cannot read properties of undefined (reading 'initWasm')`
<img width="852" height="692" alt="image" src="https://github.com/user-attachments/assets/2e19b4be-3bec-4b12-98e4-2cab096706ac" />


Root Cause
The static import at the top:
`import { Resvg, initWasm } from "@resvg/resvg-wasm"`

When this package is externalized in a UMD bundle, the import resolves to undefined because the UMD wrapper expects window.resvgWasm which doesn't exist.

Fix
Replace static import with dynamic import inside `ensureWasmInitialized()`