### PR TITLE
Fix the external glb models postition/orientation issues by adding GLTF node transform support in GLB loader

### DIFF
--- a/lib/loaders/glb.ts
+++ b/lib/loaders/glb.ts
@@ -306,7 +306,10 @@ function extractTrianglesFromGLTF(
             // Apply rotation transforms to normal (no translation)
             for (const transform of transforms) {
               if (transform.rotation) {
-                n = applyQuaternion(n, transform.rotation as [number, number, number, number])
+                n = applyQuaternion(
+                  n,
+                  transform.rotation as [number, number, number, number],
+                )
               }
             }
             normal = n
@@ -435,7 +438,10 @@ function extractTrianglesFromGLTF(
             // Apply rotation transforms to normal
             for (const transform of transforms) {
               if (transform.rotation) {
-                n = applyQuaternion(n, transform.rotation as [number, number, number, number])
+                n = applyQuaternion(
+                  n,
+                  transform.rotation as [number, number, number, number],
+                )
               }
             }
             normal = n

--- a/lib/utils/gltf-node-transforms.ts
+++ b/lib/utils/gltf-node-transforms.ts
@@ -70,9 +70,7 @@ export function applyNodeTransform(p: Point3, node: NodeTransform): Point3 {
  * Build a map of mesh index to accumulated node transforms.
  * Traverses the GLTF scene graph to collect transforms for each mesh.
  */
-export function buildMeshTransforms(
-  gltf: any,
-): Map<number, NodeTransform[]> {
+export function buildMeshTransforms(gltf: any): Map<number, NodeTransform[]> {
   const meshTransforms = new Map<number, NodeTransform[]>()
 
   if (!gltf.nodes) return meshTransforms


### PR DESCRIPTION
Root Cause: The GLB loader was ignoring GLTF node transforms (rotation, translation, scale) embedded in the file. The MachinePinMediumShort/Standard GLB files contain a quaternion rotation in their node hierarchy that positions the model correctly. our loader only extracted raw mesh geometry.

  Fixes:
  1. Added applyQuaternion() function to apply quaternion rotations to vertices
  2. Added applyNodeTransform() to apply translation, rotation, and scale from nodes
  3. Added buildMeshTransforms() to traverse the GLTF scene graph and collect transforms for each mesh
  4. Modified extractTrianglesFromGLTF() to apply node transforms to vertices when building triangles


**Before**
<img width="1876" height="815" alt="Screenshot 2025-12-23 203343" src="https://github.com/user-attachments/assets/7c3868ab-238f-43e7-a74c-e99485519aa0" />


**After**
<img width="1912" height="830" alt="Screenshot 2025-12-23 203308" src="https://github.com/user-attachments/assets/34710291-9d36-4fbf-b8ec-caa9d52cea72" />
