### PR TITLE
Add label to CAD component boxes for GLTF node naming

### DIFF
--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -368,9 +368,7 @@ export async function convertCircuitJsonTo3D(
               : hasFootprinterModel
                 ? "glb"
                 : undefined
-    const sourceComponent = db.source_component.get(
-      cad.source_component_id,
-    )
+    const sourceComponent = db.source_component.get(cad.source_component_id)
     const box: Box3D = {
       center,
       size,

--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -368,10 +368,14 @@ export async function convertCircuitJsonTo3D(
               : hasFootprinterModel
                 ? "glb"
                 : undefined
+    const sourceComponent = db.source_component.get(
+      cad.source_component_id,
+    )
     const box: Box3D = {
       center,
       size,
       isTranslucent: cad.show_as_translucent_model,
+      label: sourceComponent?.name,
     }
 
     if (


### PR DESCRIPTION
CAD components with 3D models (OBJ, STL, GLB, etc.) were missing the `label` property on their Box3D, so GLTF nodes got generic names like `OBJBox0`, `OBJBox1`. Bounding-box components already set `label: sourceComponent?.name`. This applies the same pattern to CAD components, so all GLTF nodes carry the component's reference designator (e.g. "R1", "U1"). This enables 3D viewers to identify components directly from mesh names after raycasting.