### PR TITLE
chore: bump jscad-electronics to ^0.0.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jscad/modeling": "^2.12.6",
     "earcut": "^3.0.2",
-    "jscad-electronics": "^0.0.129",
+    "jscad-electronics": "^0.0.132",
     "jscad-to-gltf": "^0.0.5",
     "occt-import-js": "^0.0.23"
   },


### PR DESCRIPTION
### Motivation
- Bump `jscad-electronics` to pick up upstream fixes and keep the project dependencies current.

### Description
- Updated `package.json` to change `jscad-electronics` from `^0.0.129` to `^0.0.132`.

### Testing
- Ran `bun test tests/` which executed 85 tests across 73 files with 82 passing and 3 failing: `STM32F100C8T6B glb snapshot`, `repro8-scale: board with ~880 plated holes`, and `cad-model-position-params-with-silkscreen`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c52bf78f08327a1568e770ece4b2c)