### PR TITLE
refactor: replace renderGLTFToPNGBufferFromGLBBuffer with renderGLTFToPNGFromGLB

### DIFF
--- a/tests/repro/repro13-to92-inline-origin-alignment.test.tsx
+++ b/tests/repro/repro13-to92-inline-origin-alignment.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import type { CadComponent } from "circuit-json"
-import { renderGLTFToPNGBufferFromGLBBuffer } from "poppygl"
+import { renderGLTFToPNGFromGLB } from "poppygl"
 import { Circuit } from "tscircuit"
 import { convertCircuitJsonTo3D, convertCircuitJsonToGltf } from "../../lib"
 import to92InlineFootprint from "../assets/TO-92_Inline.json"
@@ -94,7 +94,7 @@ test("repro13: TO-92 KiCad STEP model snapshot", async () => {
   expect((glb as ArrayBuffer).byteLength).toBeGreaterThan(0)
 
   expect(
-    renderGLTFToPNGBufferFromGLBBuffer(
+    renderGLTFToPNGFromGLB(
       glb as ArrayBuffer,
       getBestCameraPosition(circuitJson),
     ),


### PR DESCRIPTION
## Summary
- replace the removed poppygl GLB-to-PNG helper in the repro13 snapshot test
- switch the test to the current renderGLTFToPNGFromGLB API already used elsewhere in the repo

## Why
The test was still calling an older poppygl export while the rest of the codebase had already moved to the newer helper name.

## Testing
- bun test tests/repro/repro13-to92-inline-origin-alignment.test.tsx

Same as previous refactor, i missed this one previously. https://github.com/tscircuit/circuit-json-to-gltf/pull/165