### PR TITLE
fix: inherit pcb rotation for cad components

### DIFF
--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -55,6 +55,60 @@ function convertRotationFromCadRotation(rot: {
   }
 }
 
+type PcbComponentRotationSource = {
+  rotation?: number
+  ccw_rotation?: number
+} | null
+
+function getPcbComponentRotationDegrees(
+  pcbComponent: PcbComponentRotationSource | undefined,
+): number {
+  const rotation = pcbComponent?.rotation ?? pcbComponent?.ccw_rotation
+  return typeof rotation === "number" && Number.isFinite(rotation)
+    ? rotation
+    : 0
+}
+
+export function getCadComponentSceneRotation({
+  cad,
+  pcbComponent,
+  isBottomLayer,
+  usesGlbModelRotation,
+}: {
+  cad: Pick<CadComponent, "rotation">
+  pcbComponent?: PcbComponentRotationSource
+  isBottomLayer: boolean
+  usesGlbModelRotation: boolean
+}): Point3 | undefined {
+  if (cad.rotation) {
+    // Circuit JSON uses Z-up, while scene meshes use Y-up after conversion.
+    return convertRotationFromCadRotation({
+      x: cad.rotation.x,
+      y: cad.rotation.z,
+      z: cad.rotation.y,
+    })
+  }
+
+  const pcbRotation = getPcbComponentRotationDegrees(pcbComponent)
+  const boardRotation = isBottomLayer ? -pcbRotation : pcbRotation
+
+  if (isBottomLayer) {
+    return convertRotationFromCadRotation({
+      x: usesGlbModelRotation ? 0 : 180,
+      y: boardRotation,
+      z: usesGlbModelRotation ? 180 : 0,
+    })
+  }
+
+  if (boardRotation === 0) return undefined
+
+  return convertRotationFromCadRotation({
+    x: 0,
+    y: boardRotation,
+    z: 0,
+  })
+}
+
 function convertCadSizeToSceneSize(size: { x: number; y: number; z: number }): {
   x: number
   y: number
@@ -397,32 +451,14 @@ export async function convertCircuitJsonTo3D(
       box.meshType = meshType as any
     }
 
-    // Add rotation if specified
-    if (cad.rotation) {
-      // For GLB/GLTF models, we need to remap rotation axes because the coordinate
-      // system has Y and Z swapped. Circuit JSON uses Z-up, but the transformed
-      // model uses Y-up.
-      box.rotation = convertRotationFromCadRotation({
-        x: cad.rotation.x,
-        y: cad.rotation.z, // Circuit Z rotation becomes model Y rotation
-        z: cad.rotation.y, // Circuit Y rotation becomes model Z rotation
-      })
-    } else if (isBottomLayer) {
-      // If no rotation specified but component is on bottom, flip it
-      if (model_glb_url || model_gltf_url || hasFootprinterModel) {
-        box.rotation = convertRotationFromCadRotation({
-          x: 0,
-          y: 0,
-          z: 180, // Flip via Z rotation for GLB models (matches circuit JSON convention)
-        })
-      } else {
-        box.rotation = convertRotationFromCadRotation({
-          x: 180,
-          y: 0,
-          z: 0,
-        })
-      }
-    }
+    box.rotation = getCadComponentSceneRotation({
+      cad,
+      pcbComponent,
+      isBottomLayer,
+      usesGlbModelRotation: Boolean(
+        model_glb_url || model_gltf_url || hasFootprinterModel,
+      ),
+    })
 
     // Try to load the mesh with default coordinate transform if none specified
     // Note: GLB loader handles its own default Y/Z swap, so we pass through coordinateTransform

--- a/tests/unit/cad-component-rotation.test.ts
+++ b/tests/unit/cad-component-rotation.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonTo3D } from "../../lib"
+import { getCadComponentSceneRotation } from "../../lib/converters/circuit-to-3d"
+
+const SIMPLE_ASCII_STL = `solid test
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid test`
+
+const expectRadians = (actual: number | undefined, degrees: number) => {
+  expect(actual).toBeCloseTo((degrees * Math.PI) / 180)
+}
+
+test("cad component rotations inherit pcb component rotation when cad rotation is missing", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(SIMPLE_ASCII_STL, {
+        headers: { "Content-Type": "model/stl" },
+      })
+    },
+  })
+
+  try {
+    const circuit = [
+      {
+        type: "source_component",
+        source_component_id: "source1",
+        name: "R1",
+      },
+      {
+        type: "pcb_component",
+        pcb_component_id: "pcb1",
+        source_component_id: "source1",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        layer: "top",
+        rotation: 45,
+      },
+      {
+        type: "cad_component",
+        cad_component_id: "cad1",
+        pcb_component_id: "pcb1",
+        source_component_id: "source1",
+        model_stl_url: `http://127.0.0.1:${server.port}/model.stl`,
+      },
+    ] as const
+
+    const scene = await convertCircuitJsonTo3D(circuit as any, {
+      renderBoardTextures: false,
+    })
+
+    expect(scene.boxes).toHaveLength(1)
+    expectRadians(scene.boxes[0]!.rotation?.y, 45)
+  } finally {
+    await server.stop()
+  }
+})
+
+test("bottom-layer cad component rotation combines layer flip and mirrored pcb rotation", () => {
+  const rotation = getCadComponentSceneRotation({
+    cad: {},
+    pcbComponent: { rotation: 45 },
+    isBottomLayer: true,
+    usesGlbModelRotation: true,
+  })
+
+  expectRadians(rotation?.x, 0)
+  expectRadians(rotation?.y, -45)
+  expectRadians(rotation?.z, 180)
+})
+
+test("explicit cad rotation keeps existing circuit-json axis remapping", () => {
+  const rotation = getCadComponentSceneRotation({
+    cad: { rotation: { x: 10, y: 20, z: 30 } },
+    pcbComponent: { rotation: 45 },
+    isBottomLayer: false,
+    usesGlbModelRotation: false,
+  })
+
+  expectRadians(rotation?.x, 10)
+  expectRadians(rotation?.y, 30)
+  expectRadians(rotation?.z, 20)
+})


### PR DESCRIPTION
﻿Fixes #99

@algora-pbc /claim #99

## Summary
- Inherit `pcb_component.rotation`/`ccw_rotation` for CAD components when `cad_component.rotation` is missing.
- Mirror inherited PCB rotation for bottom-layer components while preserving the existing bottom-layer model flip.
- Keep explicit CAD rotation behavior and axis remapping unchanged.

## Verification
- `bun test tests/unit/cad-component-rotation.test.ts`
- `bun x biome check lib/converters/circuit-to-3d.ts tests/unit/cad-component-rotation.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`
