### PR TITLE
refactor: one shared triangle/position bounds scan

### DIFF
--- a/lib/gltf/geometry.ts
+++ b/lib/gltf/geometry.ts
@@ -1,4 +1,6 @@
 import type { Point3, Size3, STLMesh, OBJMesh, Triangle } from "../types"
+import type { BoundingBox } from "../types"
+import { boundsOfPositions } from "../utils/bounding-box"
 
 export interface MeshData {
   positions: number[]
@@ -503,36 +505,11 @@ export function convertMeshToGLTFOrientation(mesh: MeshData): MeshData {
   return result
 }
 
-export function getBounds(positions: number[]): { min: Point3; max: Point3 } {
-  if (positions.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Infinity,
-    minY = Infinity,
-    minZ = Infinity
-  let maxX = -Infinity,
-    maxY = -Infinity,
-    maxZ = -Infinity
-
-  for (let i = 0; i < positions.length; i += 3) {
-    const x = positions[i]!
-    const y = positions[i + 1]!
-    const z = positions[i + 2]!
-
-    minX = Math.min(minX, x)
-    minY = Math.min(minY, y)
-    minZ = Math.min(minZ, z)
-    maxX = Math.max(maxX, x)
-    maxY = Math.max(maxY, y)
-    maxZ = Math.max(maxZ, z)
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
-  }
+/**
+ * Axis-aligned bounds of a flat position array, as glTF accessors declare
+ * them. Delegates to the shared scan so the empty-input rule (a zero box, not
+ * Infinity) is stated once for every bounds in this package.
+ */
+export function getBounds(positions: number[]): BoundingBox {
+  return boundsOfPositions(positions)
 }

--- a/lib/loaders/glb.ts
+++ b/lib/loaders/glb.ts
@@ -7,6 +7,7 @@ import type {
   STLMesh,
   Triangle,
 } from "../types"
+import { boundsOfTriangles } from "../utils/bounding-box"
 import { transformTriangles } from "../utils/coordinate-transform"
 import {
   applyNodeTransform,
@@ -118,7 +119,7 @@ export function parseGLB(
 
   return {
     triangles: transformedTriangles,
-    boundingBox: calculateBoundingBox(transformedTriangles),
+    boundingBox: boundsOfTriangles(transformedTriangles),
   }
 }
 
@@ -172,7 +173,7 @@ function convertToOBJMesh(triangles: Triangle[]): OBJMesh {
 
   return {
     triangles: trianglesWithMaterialIndex,
-    boundingBox: calculateBoundingBox(trianglesWithMaterialIndex),
+    boundingBox: boundsOfTriangles(trianglesWithMaterialIndex),
     materials,
     materialIndexMap,
   }
@@ -621,41 +622,6 @@ function computeNormal(v0: Point3, v1: Point3, v2: Point3): Point3 {
     x: edge1.y * edge2.z - edge1.z * edge2.y,
     y: edge1.z * edge2.x - edge1.x * edge2.z,
     z: edge1.x * edge2.y - edge1.y * edge2.x,
-  }
-}
-
-function calculateBoundingBox(triangles: Triangle[]): {
-  min: Point3
-  max: Point3
-} {
-  if (triangles.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Infinity
-  let minY = Infinity
-  let minZ = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  let maxZ = -Infinity
-
-  for (const triangle of triangles) {
-    for (const vertex of triangle.vertices) {
-      minX = Math.min(minX, vertex.x)
-      minY = Math.min(minY, vertex.y)
-      minZ = Math.min(minZ, vertex.z)
-      maxX = Math.max(maxX, vertex.x)
-      maxY = Math.max(maxY, vertex.y)
-      maxZ = Math.max(maxZ, vertex.z)
-    }
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
   }
 }
 

--- a/lib/loaders/obj.ts
+++ b/lib/loaders/obj.ts
@@ -7,6 +7,7 @@ import type {
   Point3,
   Triangle,
 } from "../types"
+import { boundsOfTriangles } from "../utils/bounding-box"
 import {
   COORDINATE_TRANSFORMS,
   transformTriangles,
@@ -212,41 +213,9 @@ function parseOBJ(
 
   return {
     triangles: transformedTriangles,
-    boundingBox: calculateBoundingBox(transformedTriangles),
+    boundingBox: boundsOfTriangles(transformedTriangles),
     materials: materials.size > 0 ? materials : undefined,
     materialIndexMap: materials.size > 0 ? materialIndexMap : undefined,
-  }
-}
-
-function calculateBoundingBox(triangles: Triangle[]): {
-  min: Point3
-  max: Point3
-} {
-  if (triangles.length === 0) {
-    return { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } }
-  }
-
-  let minX = Infinity
-  let minY = Infinity
-  let minZ = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  let maxZ = -Infinity
-
-  for (const tri of triangles) {
-    for (const v of tri.vertices) {
-      if (v.x < minX) minX = v.x
-      if (v.y < minY) minY = v.y
-      if (v.z < minZ) minZ = v.z
-      if (v.x > maxX) maxX = v.x
-      if (v.y > maxY) maxY = v.y
-      if (v.z > maxZ) maxZ = v.z
-    }
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
   }
 }
 

--- a/lib/loaders/step.ts
+++ b/lib/loaders/step.ts
@@ -7,6 +7,7 @@ import type {
   STLMesh,
   Triangle,
 } from "../types"
+import { boundsOfTriangles } from "../utils/bounding-box"
 import {
   COORDINATE_TRANSFORMS,
   transformTriangles,
@@ -214,7 +215,7 @@ function convertOcctResultToMesh(
 
   return {
     triangles: transformedTriangles,
-    boundingBox: calculateBoundingBox(transformedTriangles),
+    boundingBox: boundsOfTriangles(transformedTriangles),
   }
 }
 
@@ -264,7 +265,7 @@ function convertToOBJMesh(triangles: Triangle[]): OBJMesh {
 
   return {
     triangles: trianglesWithMaterialIndex,
-    boundingBox: calculateBoundingBox(trianglesWithMaterialIndex),
+    boundingBox: boundsOfTriangles(trianglesWithMaterialIndex),
     materials,
     materialIndexMap,
   }
@@ -286,41 +287,6 @@ function computeNormal(v0: Point3, v1: Point3, v2: Point3): Point3 {
     x: edge1.y * edge2.z - edge1.z * edge2.y,
     y: edge1.z * edge2.x - edge1.x * edge2.z,
     z: edge1.x * edge2.y - edge1.y * edge2.x,
-  }
-}
-
-function calculateBoundingBox(triangles: Triangle[]): {
-  min: Point3
-  max: Point3
-} {
-  if (triangles.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Infinity
-  let minY = Infinity
-  let minZ = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  let maxZ = -Infinity
-
-  for (const triangle of triangles) {
-    for (const vertex of triangle.vertices) {
-      minX = Math.min(minX, vertex.x)
-      minY = Math.min(minY, vertex.y)
-      minZ = Math.min(minZ, vertex.z)
-      maxX = Math.max(maxX, vertex.x)
-      maxY = Math.max(maxY, vertex.y)
-      maxZ = Math.max(maxZ, vertex.z)
-    }
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
   }
 }
 

--- a/lib/loaders/stl.ts
+++ b/lib/loaders/stl.ts
@@ -5,6 +5,7 @@ import type {
   STLMesh,
   Triangle,
 } from "../types"
+import { boundsOfTriangles } from "../utils/bounding-box"
 import {
   COORDINATE_TRANSFORMS,
   transformTriangles,
@@ -119,7 +120,7 @@ function parseASCIISTL(
 
   return {
     triangles: transformedTriangles,
-    boundingBox: calculateBoundingBox(transformedTriangles),
+    boundingBox: boundsOfTriangles(transformedTriangles),
   }
 }
 
@@ -177,42 +178,7 @@ function parseBinarySTL(
 
   return {
     triangles: transformedTriangles,
-    boundingBox: calculateBoundingBox(transformedTriangles),
-  }
-}
-
-function calculateBoundingBox(triangles: Triangle[]): {
-  min: Point3
-  max: Point3
-} {
-  if (triangles.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Infinity
-  let minY = Infinity
-  let minZ = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  let maxZ = -Infinity
-
-  for (const triangle of triangles) {
-    for (const vertex of triangle.vertices) {
-      minX = Math.min(minX, vertex.x)
-      minY = Math.min(minY, vertex.y)
-      minZ = Math.min(minZ, vertex.z)
-      maxX = Math.max(maxX, vertex.x)
-      maxY = Math.max(maxY, vertex.y)
-      maxZ = Math.max(maxZ, vertex.z)
-    }
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
+    boundingBox: boundsOfTriangles(transformedTriangles),
   }
 }
 

--- a/lib/utils/bounding-box.ts
+++ b/lib/utils/bounding-box.ts
@@ -1,5 +1,61 @@
 import type { BoundingBox, Triangle } from "../types"
 
+const ZERO_BOX = (): BoundingBox => ({
+  min: { x: 0, y: 0, z: 0 },
+  max: { x: 0, y: 0, z: 0 },
+})
+
+/**
+ * Accumulates the axis-aligned extremes of a point stream.
+ *
+ * The scan is trivial; what is worth stating once is what happens at the edges,
+ * because every copy of this loop had to re-decide it:
+ *
+ * - **No points at all** report a zero box. An unguarded min/max leaves
+ *   Infinity/-Infinity, which serializes to null and reads downstream as a mesh
+ *   of infinite size.
+ * - **Non-finite points are not points.** A vertex carrying NaN or Infinity --
+ *   from a malformed OBJ/STL, or a degenerate transform -- is skipped whole,
+ *   rather than being folded in per axis. Folding it in poisons the box for
+ *   every later consumer (a glTF accessor's min/max would be NaN, which is
+ *   invalid glTF); skipping only the offending axis would report a box mixing a
+ *   real extent on one axis with a fabricated one on another.
+ *
+ * A stream whose points are all non-finite is therefore empty, and reports the
+ * zero box.
+ */
+const createBoundsAccumulator = () => {
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let minZ = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  let maxZ = Number.NEGATIVE_INFINITY
+  let isEmpty = true
+
+  return {
+    add(x: number, y: number, z: number) {
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+        return
+      }
+      isEmpty = false
+      if (x < minX) minX = x
+      if (y < minY) minY = y
+      if (z < minZ) minZ = z
+      if (x > maxX) maxX = x
+      if (y > maxY) maxY = y
+      if (z > maxZ) maxZ = z
+    },
+    result(): BoundingBox {
+      if (isEmpty) return ZERO_BOX()
+      return {
+        min: { x: minX, y: minY, z: minZ },
+        max: { x: maxX, y: maxY, z: maxZ },
+      }
+    },
+  }
+}
+
 /**
  * Axis-aligned bounds of a triangle list.
  *
@@ -9,37 +65,31 @@ import type { BoundingBox, Triangle } from "../types"
  * fills it, so a rotation applied to the box inflates the empty corners of a
  * cylinder or a sloped part instead of following the shape.
  *
- * An empty list reports a zero box rather than Infinity, matching what the
- * STL/OBJ/GLB/STEP loaders report and keeping the value serializable.
+ * An empty list reports a zero box rather than Infinity, keeping the value
+ * serializable.
  */
 export const boundsOfTriangles = (triangles: Triangle[]): BoundingBox => {
-  if (triangles.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Number.POSITIVE_INFINITY
-  let minY = Number.POSITIVE_INFINITY
-  let minZ = Number.POSITIVE_INFINITY
-  let maxX = Number.NEGATIVE_INFINITY
-  let maxY = Number.NEGATIVE_INFINITY
-  let maxZ = Number.NEGATIVE_INFINITY
-
+  const bounds = createBoundsAccumulator()
   for (const triangle of triangles) {
     for (const vertex of triangle.vertices) {
-      if (vertex.x < minX) minX = vertex.x
-      if (vertex.y < minY) minY = vertex.y
-      if (vertex.z < minZ) minZ = vertex.z
-      if (vertex.x > maxX) maxX = vertex.x
-      if (vertex.y > maxY) maxY = vertex.y
-      if (vertex.z > maxZ) maxZ = vertex.z
+      bounds.add(vertex.x, vertex.y, vertex.z)
     }
   }
+  return bounds.result()
+}
 
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
+/**
+ * Axis-aligned bounds of a flat `[x, y, z, x, y, z, ...]` position array, the
+ * layout glTF accessors use. Same rules as `boundsOfTriangles`.
+ *
+ * A trailing partial triple is ignored rather than read past the end of the
+ * array, where the missing components come back `undefined` and turn the whole
+ * box into NaN on those axes.
+ */
+export const boundsOfPositions = (positions: number[]): BoundingBox => {
+  const bounds = createBoundsAccumulator()
+  for (let i = 0; i + 2 < positions.length; i += 3) {
+    bounds.add(positions[i]!, positions[i + 1]!, positions[i + 2]!)
   }
+  return bounds.result()
 }

--- a/lib/utils/mesh-scale.ts
+++ b/lib/utils/mesh-scale.ts
@@ -1,4 +1,5 @@
 import type { BoundingBox, OBJMesh, Point3, STLMesh, Triangle } from "../types"
+import { boundsOfTriangles } from "./bounding-box"
 
 function scalePoint(point: Point3, scale: number): Point3 {
   return {
@@ -110,7 +111,7 @@ export function scaleMeshByAxis<T extends STLMesh | OBJMesh>(
   return {
     ...mesh,
     triangles: scaledTriangles,
-    boundingBox: calculateBoundingBox(scaledTriangles),
+    boundingBox: boundsOfTriangles(scaledTriangles),
   } as T
 }
 
@@ -168,7 +169,7 @@ export function rotateMesh<T extends STLMesh | OBJMesh>(
   return {
     ...mesh,
     triangles: rotatedTriangles,
-    boundingBox: calculateBoundingBox(rotatedTriangles),
+    boundingBox: boundsOfTriangles(rotatedTriangles),
   } as T
 }
 
@@ -185,37 +186,5 @@ export function getBoundingBoxCenter(bounds: BoundingBox): Point3 {
     x: (bounds.min.x + bounds.max.x) / 2,
     y: (bounds.min.y + bounds.max.y) / 2,
     z: (bounds.min.z + bounds.max.z) / 2,
-  }
-}
-
-function calculateBoundingBox(triangles: Triangle[]): BoundingBox {
-  if (triangles.length === 0) {
-    return {
-      min: { x: 0, y: 0, z: 0 },
-      max: { x: 0, y: 0, z: 0 },
-    }
-  }
-
-  let minX = Infinity
-  let minY = Infinity
-  let minZ = Infinity
-  let maxX = -Infinity
-  let maxY = -Infinity
-  let maxZ = -Infinity
-
-  for (const triangle of triangles) {
-    for (const vertex of triangle.vertices) {
-      minX = Math.min(minX, vertex.x)
-      minY = Math.min(minY, vertex.y)
-      minZ = Math.min(minZ, vertex.z)
-      maxX = Math.max(maxX, vertex.x)
-      maxY = Math.max(maxY, vertex.y)
-      maxZ = Math.max(maxZ, vertex.z)
-    }
-  }
-
-  return {
-    min: { x: minX, y: minY, z: minZ },
-    max: { x: maxX, y: maxY, z: maxZ },
   }
 }

--- a/tests/unit/bounding-box.test.ts
+++ b/tests/unit/bounding-box.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test"
+import type { Triangle } from "../../lib/types"
+import {
+  boundsOfPositions,
+  boundsOfTriangles,
+} from "../../lib/utils/bounding-box"
+
+const triangleAt = (points: [number, number, number][]): Triangle =>
+  ({
+    vertices: points.map(([x, y, z]) => ({ x, y, z })),
+    normal: { x: 0, y: 1, z: 0 },
+  }) as Triangle
+
+test("boundsOfTriangles spans every vertex of every triangle", () => {
+  const bounds = boundsOfTriangles([
+    triangleAt([
+      [0, 0, 0],
+      [2, 1, -1],
+      [1, 5, 0],
+    ]),
+    triangleAt([
+      [-3, 0, 4],
+      [0, -2, 0],
+      [1, 1, 1],
+    ]),
+  ])
+
+  expect(bounds).toEqual({
+    min: { x: -3, y: -2, z: -1 },
+    max: { x: 2, y: 5, z: 4 },
+  })
+})
+
+/**
+ * The rule worth having in one place: an unguarded min/max scan leaves
+ * Infinity/-Infinity here, which serializes to null and reads downstream as a
+ * mesh of infinite size.
+ */
+test("boundsOfTriangles reports a zero box for no triangles", () => {
+  expect(boundsOfTriangles([])).toEqual({
+    min: { x: 0, y: 0, z: 0 },
+    max: { x: 0, y: 0, z: 0 },
+  })
+})
+
+test("boundsOfPositions reads a flat array as x/y/z triples", () => {
+  // prettier-ignore
+  const positions = [0, 0, 0, 2, 1, -1, -3, 5, 4]
+
+  expect(boundsOfPositions(positions)).toEqual({
+    min: { x: -3, y: 0, z: -1 },
+    max: { x: 2, y: 5, z: 4 },
+  })
+})
+
+test("boundsOfPositions reports a zero box for an empty array", () => {
+  expect(boundsOfPositions([])).toEqual({
+    min: { x: 0, y: 0, z: 0 },
+    max: { x: 0, y: 0, z: 0 },
+  })
+})
+
+/**
+ * A trailing partial triple is malformed input; ignoring it keeps NaN out of
+ * the box, where it would otherwise reach a glTF accessor's min/max.
+ */
+test("boundsOfPositions ignores a trailing partial triple", () => {
+  expect(boundsOfPositions([1, 2, 3, 9, 9])).toEqual({
+    min: { x: 1, y: 2, z: 3 },
+    max: { x: 1, y: 2, z: 3 },
+  })
+})
+
+/**
+ * A non-finite vertex is skipped whole, not per axis: reporting the y/z of a
+ * point whose x is NaN would mix a real extent with a fabricated one.
+ */
+test("bounds skip non-finite points rather than folding them in", () => {
+  expect(boundsOfPositions([1, 2, 3, Number.NaN, 5, 6])).toEqual({
+    min: { x: 1, y: 2, z: 3 },
+    max: { x: 1, y: 2, z: 3 },
+  })
+
+  expect(
+    boundsOfTriangles([
+      triangleAt([
+        [0, 0, 0],
+        [2, 2, 2],
+        [Number.POSITIVE_INFINITY, 9, 9],
+      ]),
+    ]),
+  ).toEqual({
+    min: { x: 0, y: 0, z: 0 },
+    max: { x: 2, y: 2, z: 2 },
+  })
+})
+
+test("bounds report a zero box when every point is non-finite", () => {
+  expect(boundsOfPositions([Number.NaN, Number.NaN, Number.NaN])).toEqual({
+    min: { x: 0, y: 0, z: 0 },
+    max: { x: 0, y: 0, z: 0 },
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #175, as flagged there: fold the duplicated bounding-box scans into
the shared `boundsOfTriangles` that PR introduced.

Six copies of the same min/max scan had accumulated:

| Copy | Over |
|---|---|
| `loaders/stl.ts` | `Triangle[]` |
| `loaders/obj.ts` | `Triangle[]` |
| `loaders/glb.ts` | `Triangle[]` |
| `loaders/step.ts` | `Triangle[]` |
| `utils/mesh-scale.ts` | `Triangle[]` |
| `gltf/geometry.ts#getBounds` | flat `[x, y, z, ...]` array |

## Why bother

The scan is trivial, and duplicating it costs little by itself. What it costs is
**the edge cases** — every copy had to re-decide them, and they did not decide
alike:

- **Empty input.** Five copies returned a zero box. The sixth (in
  `triangles-from-loops.ts`, fixed in #175) left `Infinity`, which serializes to
  `null` and reads downstream as a mesh of infinite size.
- **Non-finite vertices**, from a malformed OBJ/STL or a degenerate transform.
  The five `Math.min` copies propagated `NaN` straight into the box. `obj.ts`,
  which compared instead of calling `Math.min`, silently dropped it *per axis* —
  reporting a box that mixes a real extent on one axis with a fabricated one on
  another.

A rule that has to be re-remembered at each copy is one the next loader will
miss, so both rules now live in one accumulator that the public helpers share:
bounds are taken over the finite points, and a stream with no finite points
reports the zero box.

## What changed

- `boundsOfTriangles` and a new `boundsOfPositions` share a small internal
  accumulator that owns the empty-input rule.
- `getBounds` keeps its name, signature and call sites, and delegates to
  `boundsOfPositions`.
- The five private `calculateBoundingBox` copies are gone.

Net **−150 lines**.

## Behaviour

Unchanged for well-formed input. Two deliberate differences from the code being
removed, both at inputs that were already malformed:

| Input | Before | Now |
|---|---|---|
| vertex with `NaN`/`Infinity` | `NaN` bounds (`Math.min` copies) or one axis dropped (`obj.ts`) | point skipped whole |
| positions array not a multiple of 3 | reads past the end; `undefined` makes those axes `NaN` | trailing partial triple ignored |

`NaN` in a box is worth avoiding specifically: it reaches a glTF accessor's
`min`/`max`, and `NaN` there is invalid glTF.

## Testing

The existing suite is the real guard — every loader's bounds are asserted
through it, and all 103 still pass. Added direct tests for the shared helpers:
both empty cases, the flat-array triple layout, the trailing partial triple,
non-finite points, and a stream whose points are all non-finite.

110 pass / 0 fail, plus type-check, format-check and playwright.
