### PR TITLE
Say when a footprint has no 3D model instead of dropping it silently

### DIFF
--- a/lib/loaders/footprinter.ts
+++ b/lib/loaders/footprinter.ts
@@ -19,6 +19,17 @@ async function generateFootprinterMesh(
   )
 
   if (!renderedModel?.geometries?.length) {
+    // Not an error upstream -- jscad-electronics returns an empty model for any
+    // footprint it has no body for -- but the caller drops such a component
+    // from the scene entirely, so without this the part simply is not on the
+    // board and nothing says why. Parametric chip footprints (`res_p0.86mm_...`)
+    // hit this for every passive on a board at once.
+    //
+    // Warned once per footprint: the cache below holds the promise, so a board
+    // with forty identical resistors reports one line, not forty.
+    console.warn(
+      `No 3D model for footprint "${footprinterString}" (jscad-electronics returned no geometry) - the component will not appear in the 3D scene.`,
+    )
     return undefined
   }
 
@@ -53,4 +64,13 @@ export function loadFootprinterModel(
   }
 
   return footprinterCache.get(cacheKey)!
+}
+
+/**
+ * Drop memoized footprint meshes. Mirrors `clearOBJCache`; the cache also
+ * memoizes the "no model" answer, and with it the one warning that answer
+ * emits, so tests that assert on the warning have to be able to reset it.
+ */
+export function clearFootprinterCache() {
+  footprinterCache.clear()
 }

--- a/tests/unit/footprinter-empty-model-warning.test.ts
+++ b/tests/unit/footprinter-empty-model-warning.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import {
+  clearFootprinterCache,
+  loadFootprinterModel,
+} from "../../lib/loaders/footprinter"
+
+const captureWarnings = async (run: () => Promise<unknown>) => {
+  const warnings: string[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "))
+  }
+  try {
+    await run()
+  } finally {
+    console.warn = original
+  }
+  return warnings
+}
+
+/**
+ * A footprint jscad-electronics has no body for returns an empty model rather
+ * than throwing, and `circuit-to-3d` drops such a component from the scene
+ * entirely. Silent on both sides, the part is simply absent from the render
+ * with nothing to search for -- which is how a board lost 26 of its 36 passives
+ * without a single line of output.
+ */
+test("an empty generated model says so", async () => {
+  clearFootprinterCache()
+
+  const warnings = await captureWarnings(() =>
+    loadFootprinterModel("res_p0.8656mm_pw0.5657mm_ph0.54mm"),
+  )
+
+  expect(warnings).toHaveLength(1)
+  expect(warnings[0]).toContain("res_p0.8656mm_pw0.5657mm_ph0.54mm")
+  expect(warnings[0]).toContain("3D scene")
+})
+
+/**
+ * A board typically repeats a passive footprint dozens of times. One line per
+ * footprint is a diagnostic; one per component is noise that gets filtered out.
+ */
+test("a repeated footprint warns once, not once per component", async () => {
+  clearFootprinterCache()
+
+  const warnings = await captureWarnings(async () => {
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        loadFootprinterModel("res_p0.8656mm_pw0.5657mm_ph0.54mm"),
+      ),
+    )
+  })
+
+  expect(warnings).toHaveLength(1)
+})
+
+test("a footprint that does render stays quiet", async () => {
+  clearFootprinterCache()
+
+  const warnings = await captureWarnings(() => loadFootprinterModel("0402"))
+
+  expect(warnings).toEqual([])
+})


### PR DESCRIPTION
`getJscadModelForFootprint` returns an empty model, not an error, for any
footprint jscad-electronics has no body for. `circuit-to-3d` then skips
the component entirely:

    // Skip empty generated footprint models unless debug boxes are requested.
    if (!box.mesh) {
      if (hasFootprinterModel && !showBoundingBoxes) continue

Silent on both sides, so the part is absent from the scene with nothing
logged and nothing to search for. Parametric chip footprints
(`res_p0.8656mm_...`) currently produce no body at all, which took 26 of
36 passives off one board -- every resistor among them -- and the only
signal was noticing they were missing by eye.

The loader already warns when generation *throws*; generating nothing said
nothing. Warn there too, naming the footprint and what follows from it.

Warned once per footprint rather than once per component: the promise
cache already dedupes, so a board with forty identical resistors reports
one line. `clearFootprinterCache` is exported to reset that in tests,
mirroring `clearOBJCache`.

This does not change what renders. The empty model is jscad-electronics'
to fix (tscircuit/jscad-electronics#319); this is about not hiding it.
