### PR TITLE
Derive board colors from solder-mask metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,24 @@ convertCircuitJsonToGltf(circuitJson: CircuitJson, options?: ConversionOptions):
 
 - `format`: "gltf" (JSON) or "glb" (binary) - default: "gltf"
 - `boardTextureResolution`: Resolution for board texture rendering - default: 1024
-- `showPcbNotes`: Include `pcb_note*` elements in board texture rendering (default: `false`)Run bunx tsc --noEmit.
+- `showPcbNotes`: Include `pcb_note*` elements in board texture rendering (default: `false`)
 - `boardDrillQuality`: Drill geometry detail level, "high" or "fast" - default: "fast"
 - `drawFauxBoard`: Draw a fallback board if no `pcb_board` or `pcb_panel` is present - default: false
 - `includeModels`: Whether to load external 3D models - default: true
 - `modelCache`: Map for caching loaded models
-- `backgroundColor`: Board texture background color
-- `boardSideColor`: Physical substrate/edge color (defaults to `backgroundColor` when customized)
+- `backgroundColor`: Board texture background color; overrides `pcb_board.solder_mask_color`
+- `boardSideColor`: Physical substrate/edge color; otherwise derived from the solder-mask color
 - `copperColor`: Exposed copper color in board textures
-- `silkscreenColor`: Silkscreen color in board textures
-- `solderMaskWithCopperColor`: Color of traces and copper covered by solder mask
+- `silkscreenColor`: Silkscreen color in board textures; overrides `pcb_board.silkscreen_color`
+- `solderMaskWithCopperColor`: Color of traces and copper covered by solder mask; otherwise derived from the solder-mask color
 - `drillColor`: Drill opening color in board textures
 - `showBoundingBoxes`: Show bounding boxes for debugging (default: `false`)
 - `projectBaseUrl`: Optional base URL used to resolve `node_modules` model assets via `/package_files/download`
 - `authHeaders`: Optional auth headers for model downloads, e.g. `{ Authorization: "Bearer ..." }`
+
+When a `pcb_board` supplies `solder_mask_color`, the renderer uses it for the
+board surface and derives contrasting covered-copper, substrate-edge, and
+silkscreen colors. Explicit conversion options take precedence.
 
 ## Architecture
 

--- a/lib/converters/board-renderer.ts
+++ b/lib/converters/board-renderer.ts
@@ -1,21 +1,31 @@
 import type { CircuitJson } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import type { BoardRenderOptions } from "../types"
+import { getBoardColorPalette } from "../utils/board-color-palette"
 
 export async function renderBoardLayer(
   circuitJson: CircuitJson,
   options: BoardRenderOptions,
 ): Promise<string> {
+  const palette = getBoardColorPalette(circuitJson, {
+    solderMaskColor: options.backgroundColor,
+    silkscreenColor: options.silkscreenColor,
+  })
   const {
     layer,
     resolution = 1024,
-    backgroundColor = "transparent",
     copperColor = "#ffe066",
-    silkscreenColor = "#ffffff",
-    solderMaskWithCopperColor = "#69e778ff",
     drillColor = "rgba(0,0,0,0.5)",
     showPcbNotes = false,
   } = options
+  const backgroundColor =
+    options.backgroundColor ?? palette.backgroundColor ?? "transparent"
+  const silkscreenColor =
+    options.silkscreenColor ?? palette.silkscreenColor ?? "#ffffff"
+  const solderMaskWithCopperColor =
+    options.solderMaskWithCopperColor ??
+    palette.solderMaskWithCopperColor ??
+    "#69e778ff"
 
   const svg = convertCircuitJsonToPcbSvg(circuitJson, {
     layer,
@@ -25,6 +35,14 @@ export async function renderBoardLayer(
     showSolderMask: true,
     showPcbNotes,
     colorOverrides: {
+      soldermask: {
+        top: backgroundColor,
+        bottom: backgroundColor,
+      },
+      soldermaskOverCopper: {
+        top: solderMaskWithCopperColor,
+        bottom: solderMaskWithCopperColor,
+      },
       copper: {
         top: copperColor,
         bottom: copperColor,
@@ -122,7 +140,7 @@ export async function renderBoardTextures(
   circuitJson: CircuitJson,
   {
     resolution = 1024,
-    backgroundColor = "#0F3812",
+    backgroundColor,
     copperColor,
     silkscreenColor,
     solderMaskWithCopperColor,
@@ -133,25 +151,38 @@ export async function renderBoardTextures(
   top: string
   bottom: string
 }> {
+  const palette = getBoardColorPalette(circuitJson, {
+    solderMaskColor: backgroundColor,
+    silkscreenColor,
+  })
+  const resolvedBackgroundColor =
+    backgroundColor ?? palette.backgroundColor ?? "#0F3812"
+  const resolvedSilkscreenColor =
+    silkscreenColor ?? palette.silkscreenColor ?? "#ffffff"
+  const resolvedSolderMaskWithCopperColor =
+    solderMaskWithCopperColor ??
+    palette.solderMaskWithCopperColor ??
+    "#69e778ff"
+
   // Render sequentially to avoid concurrent Resvg WASM usage
   // which causes "recursive use of an object" Rust aliasing errors
   const top = await renderBoardLayer(circuitJson, {
     layer: "top",
     resolution,
-    backgroundColor,
+    backgroundColor: resolvedBackgroundColor,
     copperColor,
-    silkscreenColor,
-    solderMaskWithCopperColor,
+    silkscreenColor: resolvedSilkscreenColor,
+    solderMaskWithCopperColor: resolvedSolderMaskWithCopperColor,
     drillColor,
     showPcbNotes,
   })
   const bottom = await renderBoardLayer(circuitJson, {
     layer: "bottom",
     resolution,
-    backgroundColor,
+    backgroundColor: resolvedBackgroundColor,
     copperColor,
-    silkscreenColor,
-    solderMaskWithCopperColor,
+    silkscreenColor: resolvedSilkscreenColor,
+    solderMaskWithCopperColor: resolvedSolderMaskWithCopperColor,
     drillColor,
     showPcbNotes,
   })

--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -36,6 +36,10 @@ import {
 import { filterCutoutsForBoard } from "../utils/pcb-board-cutouts"
 import { createBoardMesh } from "../utils/pcb-board-geometry"
 import { createPanelMesh } from "../utils/pcb-panel-geometry"
+import {
+  colorToCssString,
+  getBoardColorPalette,
+} from "../utils/board-color-palette"
 import { renderBoardTextures } from "./board-renderer"
 
 const DEFAULT_BOARD_THICKNESS = 1.6 // mm
@@ -96,18 +100,25 @@ export async function convertCircuitJsonTo3D(
   const db: any = cju(circuitJson)
   const boxes: Box3D[] = []
 
-  const resolvedBoardSideColor =
-    boardSideColor ?? (options.pcbColor !== undefined ? pcbColor : undefined)
+  const palette = getBoardColorPalette(circuitJson, {
+    solderMaskColor:
+      options.pcbColor !== undefined
+        ? colorToCssString(options.pcbColor)
+        : undefined,
+    silkscreenColor,
+  })
+  const resolvedPcbColor =
+    options.pcbColor ?? palette.backgroundColor ?? pcbColor
+  const resolvedBoardSideColor = boardSideColor ?? palette.boardSideColor
 
   const boardTextureColors = {
-    ...(typeof options.pcbColor === "string"
-      ? { backgroundColor: options.pcbColor }
-      : {}),
+    backgroundColor: palette.backgroundColor,
     ...(typeof options.copperColor === "string"
       ? { copperColor: options.copperColor }
       : {}),
-    silkscreenColor,
-    solderMaskWithCopperColor,
+    silkscreenColor: silkscreenColor ?? palette.silkscreenColor,
+    solderMaskWithCopperColor:
+      solderMaskWithCopperColor ?? palette.solderMaskWithCopperColor,
     drillColor,
   }
 
@@ -150,7 +161,7 @@ export async function convertCircuitJsonTo3D(
         z: Number.isFinite(meshHeight) ? meshHeight : pcbPanel.height,
       },
       mesh: panelMesh,
-      color: pcbColor,
+      color: resolvedPcbColor,
       sideColor: resolvedBoardSideColor,
     }
 
@@ -169,11 +180,11 @@ export async function convertCircuitJsonTo3D(
       } catch (error) {
         console.warn("Failed to render panel textures:", error)
         // If texture rendering fails, use the fallback color
-        panelBox.color = pcbColor
+        panelBox.color = resolvedPcbColor
       }
     } else {
       // No textures requested, use solid color
-      panelBox.color = pcbColor
+      panelBox.color = resolvedPcbColor
     }
 
     boxes.push(panelBox)
@@ -208,7 +219,7 @@ export async function convertCircuitJsonTo3D(
         z: Number.isFinite(meshHeight) ? meshHeight : pcbBoard.height,
       },
       mesh: boardMesh,
-      color: pcbColor,
+      color: resolvedPcbColor,
       sideColor: resolvedBoardSideColor,
     }
 
@@ -227,11 +238,11 @@ export async function convertCircuitJsonTo3D(
       } catch (error) {
         console.warn("Failed to render board textures:", error)
         // If texture rendering fails, use the fallback color
-        boardBox.color = pcbColor
+        boardBox.color = resolvedPcbColor
       }
     } else {
       // No textures requested, use solid color
-      boardBox.color = pcbColor
+      boardBox.color = resolvedPcbColor
     }
 
     boxes.push(boardBox)
@@ -267,7 +278,7 @@ export async function convertCircuitJsonTo3D(
         y: effectiveBoardThickness,
         z: fauxHeight,
       },
-      color: pcbColor,
+      color: resolvedPcbColor,
       sideColor: resolvedBoardSideColor,
     }
 
@@ -303,7 +314,7 @@ export async function convertCircuitJsonTo3D(
         }
       } catch (error) {
         console.warn("Failed to render faux board textures:", error)
-        fauxBoardBox.color = pcbColor
+        fauxBoardBox.color = resolvedPcbColor
       }
     }
 

--- a/lib/utils/board-color-palette.ts
+++ b/lib/utils/board-color-palette.ts
@@ -1,0 +1,162 @@
+import type { CircuitJson, PcbBoard } from "circuit-json"
+import type { Color } from "../types"
+
+type Rgb = [number, number, number]
+
+export interface BoardColorPalette {
+  backgroundColor?: string
+  boardSideColor?: string
+  solderMaskWithCopperColor?: string
+  silkscreenColor?: string
+}
+
+const BOARD_COLOR_PRESETS: Record<string, string> = {
+  green: "#0f3812",
+  red: "#8b1e1e",
+  blue: "#173f68",
+  purple: "#562b7c",
+  black: "#111111",
+  white: "#ffffff",
+  yellow: "#d1a800",
+  gray: "#808080",
+  grey: "#808080",
+}
+
+const clampByte = (value: number) =>
+  Math.max(0, Math.min(255, Math.round(value)))
+
+const toHex = ([red, green, blue]: Rgb) =>
+  `#${[red, green, blue]
+    .map((channel) => clampByte(channel).toString(16).padStart(2, "0"))
+    .join("")}`
+
+const parseHexColor = (value: string): Rgb | undefined => {
+  const hex = value.slice(1)
+  if (hex.length === 3 || hex.length === 4) {
+    return [
+      Number.parseInt(`${hex[0]}${hex[0]}`, 16),
+      Number.parseInt(`${hex[1]}${hex[1]}`, 16),
+      Number.parseInt(`${hex[2]}${hex[2]}`, 16),
+    ]
+  }
+  if (hex.length === 6 || hex.length === 8) {
+    return [
+      Number.parseInt(hex.slice(0, 2), 16),
+      Number.parseInt(hex.slice(2, 4), 16),
+      Number.parseInt(hex.slice(4, 6), 16),
+    ]
+  }
+  return undefined
+}
+
+const parseRgbChannel = (value: string) =>
+  value.endsWith("%")
+    ? (Number.parseFloat(value) / 100) * 255
+    : Number.parseFloat(value)
+
+const parseRgbColor = (value: string): Rgb | undefined => {
+  const match = value.match(/^rgba?\(([^)]+)\)$/i)
+  if (!match) return undefined
+
+  const channels = match[1]!
+    .split(",")
+    .slice(0, 3)
+    .map((channel) => parseRgbChannel(channel.trim()))
+  if (
+    channels.length !== 3 ||
+    channels.some((channel) => !Number.isFinite(channel))
+  ) {
+    return undefined
+  }
+  return channels.map(clampByte) as Rgb
+}
+
+const parseColor = (value: string): Rgb | undefined => {
+  const normalized = value.trim().toLowerCase()
+  const preset = BOARD_COLOR_PRESETS[normalized]
+  const resolved = preset ?? normalized
+  if (resolved.startsWith("#")) return parseHexColor(resolved)
+  return parseRgbColor(resolved)
+}
+
+const normalizeColor = (value?: string) => {
+  if (!value || value.trim().toLowerCase() === "not_specified") {
+    return undefined
+  }
+  const parsed = parseColor(value)
+  return parsed ? toHex(parsed) : value.trim()
+}
+
+const mix = (color: Rgb, target: Rgb, amount: number): Rgb =>
+  color.map((channel, index) =>
+    clampByte(channel + (target[index]! - channel) * amount),
+  ) as Rgb
+
+const getPerceivedBrightness = ([red, green, blue]: Rgb) =>
+  (red * 0.299 + green * 0.587 + blue * 0.114) / 255
+
+export const colorToCssString = (color: Color): string => {
+  if (typeof color === "string") return color
+  return toHex([color[0], color[1], color[2]])
+}
+
+export function deriveBoardColorPalette(
+  solderMaskColor: string,
+  silkscreenColor?: string,
+): BoardColorPalette {
+  const backgroundColor = normalizeColor(solderMaskColor)
+  if (!backgroundColor) {
+    return { silkscreenColor: normalizeColor(silkscreenColor) }
+  }
+
+  const maskRgb = parseColor(backgroundColor)
+  if (!maskRgb) {
+    return {
+      backgroundColor,
+      boardSideColor: backgroundColor,
+      solderMaskWithCopperColor: backgroundColor,
+      silkscreenColor: normalizeColor(silkscreenColor) ?? "#ffffff",
+    }
+  }
+
+  const isLight = getPerceivedBrightness(maskRgb) >= 0.6
+  const coveredCopper = mix(
+    maskRgb,
+    isLight ? [0, 0, 0] : [255, 255, 255],
+    isLight ? 0.28 : 0.32,
+  )
+  const boardSide = mix(maskRgb, [0, 0, 0], isLight ? 0.14 : 0.24)
+
+  return {
+    backgroundColor: toHex(maskRgb),
+    boardSideColor: toHex(boardSide),
+    solderMaskWithCopperColor: toHex(coveredCopper),
+    silkscreenColor:
+      normalizeColor(silkscreenColor) ?? (isLight ? "#111827" : "#ffffff"),
+  }
+}
+
+export function getBoardColorPalette(
+  circuitJson: CircuitJson,
+  overrides: {
+    solderMaskColor?: string
+    silkscreenColor?: string
+  } = {},
+): BoardColorPalette {
+  const board = circuitJson.find(
+    (element): element is PcbBoard => element.type === "pcb_board",
+  )
+  const legacyBoard = board as
+    | (PcbBoard & { soldermask_color?: string })
+    | undefined
+  const solderMaskColor =
+    overrides.solderMaskColor ??
+    board?.solder_mask_color ??
+    legacyBoard?.soldermask_color
+  const silkscreenColor = overrides.silkscreenColor ?? board?.silkscreen_color
+
+  if (!solderMaskColor) {
+    return { silkscreenColor: normalizeColor(silkscreenColor) }
+  }
+  return deriveBoardColorPalette(solderMaskColor, silkscreenColor)
+}

--- a/tests/integration/circuit-to-gltf.test.ts
+++ b/tests/integration/circuit-to-gltf.test.ts
@@ -33,14 +33,14 @@ test("convertCircuitJsonToGltf should convert circuit to GLB", async () => {
   expect((result as ArrayBuffer).byteLength).toBeGreaterThan(0)
 })
 
-test("custom board color applies to textured board sides", async () => {
+test("custom board color derives textured board sides", async () => {
   const result = await convertCircuitJsonToGltf(simpleCircuit as any, {
     boardTextureResolution: 64,
     backgroundColor: "#aeb8c6",
   })
 
   const gltf = result as any
-  const expectedSideColor = [174 / 255, 184 / 255, 198 / 255, 1]
+  const expectedSideColor = [150 / 255, 158 / 255, 170 / 255, 1]
   const hasExpectedSideMaterial = gltf.materials.some((material: any) =>
     material.pbrMetallicRoughness?.baseColorFactor?.every(
       (channel: number, index: number) =>
@@ -49,6 +49,36 @@ test("custom board color applies to textured board sides", async () => {
   )
 
   expect(hasExpectedSideMaterial).toBe(true)
+})
+
+test("pcb_board solder mask derives board colors unless explicitly overridden", async () => {
+  const circuitWithBoardColors = simpleCircuit.map((element) =>
+    element.type === "pcb_board"
+      ? {
+          ...element,
+          solder_mask_color: "#aeb8c6",
+          silkscreen_color: "#ffffff",
+        }
+      : element,
+  )
+
+  const derivedScene = await convertCircuitJsonTo3D(
+    circuitWithBoardColors as any,
+    { renderBoardTextures: false },
+  )
+  expect(derivedScene.boxes[0]?.color).toBe("#aeb8c6")
+  expect(derivedScene.boxes[0]?.sideColor).toBe("#969eaa")
+
+  const overriddenScene = await convertCircuitJsonTo3D(
+    circuitWithBoardColors as any,
+    {
+      pcbColor: "#112233",
+      boardSideColor: "#445566",
+      renderBoardTextures: false,
+    },
+  )
+  expect(overriddenScene.boxes[0]?.color).toBe("#112233")
+  expect(overriddenScene.boxes[0]?.sideColor).toBe("#445566")
 })
 
 test("convertCircuitJsonTo3D should create 3D scene", async () => {

--- a/tests/snapshot/custom-board-texture-colors.test.ts
+++ b/tests/snapshot/custom-board-texture-colors.test.ts
@@ -12,6 +12,8 @@ const circuitJson: CircuitJson = [
     thickness: 1.6,
     num_layers: 2,
     material: "fr4",
+    solder_mask_color: "#aeb8c6",
+    silkscreen_color: "#ffffff",
   },
   {
     type: "pcb_trace",
@@ -23,14 +25,10 @@ const circuitJson: CircuitJson = [
   },
 ]
 
-test("customizes solder-mask-covered copper independently", async () => {
+test("derives board texture colors from pcb_board metadata", async () => {
   const dataUrl = await renderBoardLayer(circuitJson, {
     layer: "top",
     resolution: 320,
-    backgroundColor: "#aeb8c6",
-    copperColor: "#c99f4e",
-    solderMaskWithCopperColor: "#7f8a99",
-    silkscreenColor: "#ffffff",
   })
 
   const png = Buffer.from(dataUrl.split(",")[1]!, "base64")

--- a/tests/unit/board-color-palette.test.ts
+++ b/tests/unit/board-color-palette.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import {
+  deriveBoardColorPalette,
+  getBoardColorPalette,
+} from "../../lib/utils/board-color-palette"
+
+test("derives a complete palette from a light solder mask", () => {
+  expect(deriveBoardColorPalette("#aeb8c6")).toEqual({
+    backgroundColor: "#aeb8c6",
+    boardSideColor: "#969eaa",
+    solderMaskWithCopperColor: "#7d848f",
+    silkscreenColor: "#111827",
+  })
+})
+
+test("derives contrasting colors for named dark solder masks", () => {
+  expect(deriveBoardColorPalette("green")).toEqual({
+    backgroundColor: "#0f3812",
+    boardSideColor: "#0b2b0e",
+    solderMaskWithCopperColor: "#5c785e",
+    silkscreenColor: "#ffffff",
+  })
+})
+
+test("uses pcb_board colors and supports the soldermask_color alias", () => {
+  const canonicalCircuit: CircuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 2,
+      material: "fr4",
+      solder_mask_color: "#aeb8c6",
+      silkscreen_color: "white",
+    },
+  ]
+  const aliasCircuit = [
+    {
+      ...canonicalCircuit[0],
+      solder_mask_color: undefined,
+      soldermask_color: "#aeb8c6",
+    },
+  ] as unknown as CircuitJson
+
+  expect(getBoardColorPalette(canonicalCircuit)).toEqual(
+    getBoardColorPalette(aliasCircuit),
+  )
+  expect(getBoardColorPalette(canonicalCircuit).silkscreenColor).toBe("#ffffff")
+})


### PR DESCRIPTION
## Summary

- use `pcb_board.solder_mask_color` as the default board-surface color
- derive covered-copper, substrate-edge, and contrasting silkscreen colors from that mask
- honor `pcb_board.silkscreen_color`, while keeping explicit renderer options highest priority
- support named tscircuit board colors, hex/rgb values, and the legacy `soldermask_color` spelling
- preserve the existing fallback palette when no board metadata or explicit mask color is present

## Why

The renderer treated the board surface, mask-covered traces, and substrate sides as independent defaults. As a result, changing a board's solder-mask color could still leave hardcoded green materials in the 3D render. This centralizes those defaults around the board metadata introduced by the circuit and follows up on #179.

Callers can now set `solderMaskColor` and `silkscreenColor` on the tscircuit board instead of reproducing a renderer-specific color palette.

## Validation

- `bun test` — 116 passed
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- rendered the RP2040 hero using board metadata only; mask-covered traces and board sides both derive from `#aeb8c6`
