### PR TITLE
feat: export CAD hidden-edge hints for PoppyGL

### DIFF
--- a/lib/converters/circuit-to-3d.ts
+++ b/lib/converters/circuit-to-3d.ts
@@ -418,6 +418,8 @@ export async function convertCircuitJsonTo3D(
       center,
       size,
       isTranslucent: cad.show_as_translucent_model,
+      showHiddenEdges: (cad as CadComponent & { show_hidden_edges?: boolean })
+        .show_hidden_edges,
       label: sourceComponent?.name,
     }
 

--- a/lib/gltf/gltf-builder.ts
+++ b/lib/gltf/gltf-builder.ts
@@ -149,6 +149,7 @@ export class GLTFBuilder {
       name: box.label || `Box${nodeIndex}`,
       mesh: meshIndex,
       translation: this.toGltfTranslation(box.center),
+      ...this.getPoppyglNodeExtras(box),
     })
 
     // Add node to scene
@@ -249,6 +250,7 @@ export class GLTFBuilder {
       name: box.label || `OBJBox${nodeIndex}`,
       mesh: meshIndex,
       translation: this.toGltfTranslation(box.center),
+      ...this.getPoppyglNodeExtras(box),
     })
 
     // Add node to scene
@@ -469,6 +471,7 @@ export class GLTFBuilder {
       name: box.label || `Box${nodeIndex}`,
       mesh: meshIndex,
       translation: this.toGltfTranslation(box.center),
+      ...this.getPoppyglNodeExtras(box),
     })
 
     // Add node to scene
@@ -624,6 +627,7 @@ export class GLTFBuilder {
       name: box.label || `Box${nodeIndex}`,
       mesh: meshIndex,
       translation: this.toGltfTranslation(box.center),
+      ...this.getPoppyglNodeExtras(box),
     })
 
     // Add node to scene
@@ -696,6 +700,18 @@ export class GLTFBuilder {
 
   private toGltfTranslation(center: Box3D["center"]): [number, number, number] {
     return [-center.x, center.y, center.z]
+  }
+
+  private getPoppyglNodeExtras(box: Box3D): Partial<Pick<GLTFNode, "extras">> {
+    if (!box.showHiddenEdges) return {}
+
+    return {
+      extras: {
+        poppygl: {
+          showHiddenEdges: true,
+        },
+      },
+    }
   }
 
   private getMeshCacheKey(meshData: MeshData, materialIndex: number): string {

--- a/lib/gltf/gltf-types.ts
+++ b/lib/gltf/gltf-types.ts
@@ -32,6 +32,11 @@ export interface GLTFNode {
   scale?: [number, number, number]
   matrix?: number[]
   children?: number[]
+  extras?: {
+    poppygl?: {
+      showHiddenEdges?: boolean
+    }
+  }
 }
 
 export interface GLTFMesh {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -107,6 +107,7 @@ export interface Box3D {
   label?: string
   labelColor?: Color
   isTranslucent?: boolean
+  showHiddenEdges?: boolean
 }
 
 export interface Scene3D {

--- a/tests/unit/hidden-edges.test.ts
+++ b/tests/unit/hidden-edges.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonTo3D } from "../../lib/converters/circuit-to-3d"
+import { convertSceneToGLTF } from "../../lib/converters/scene-to-gltf"
+
+test("carries cad_component.show_hidden_edges into PoppyGL node extras", async () => {
+  const circuit = [
+    {
+      type: "source_component",
+      source_component_id: "source_enclosure",
+      name: "enclosure",
+      supplier_part_numbers: {},
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_enclosure",
+      source_component_id: "source_enclosure",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      layer: "top",
+      rotation: 0,
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_enclosure",
+      pcb_component_id: "pcb_enclosure",
+      source_component_id: "source_enclosure",
+      position: { x: 0, y: 0, z: 0 },
+      size: { x: 10, y: 10, z: 10 },
+      model_jscad: { type: "cuboid", size: [10, 10, 10] },
+      show_hidden_edges: true,
+    },
+  ]
+
+  const scene = await convertCircuitJsonTo3D(circuit as any, {
+    renderBoardTextures: false,
+  })
+  expect(scene.boxes[0]?.showHiddenEdges).toBe(true)
+
+  const gltf = (await convertSceneToGLTF(scene, { binary: false })) as {
+    nodes: Array<{ name?: string; extras?: unknown }>
+  }
+  expect(gltf.nodes.find((node) => node.name === "enclosure")?.extras).toEqual({
+    poppygl: { showHiddenEdges: true },
+  })
+})


### PR DESCRIPTION
## Summary

- carry `cad_component.show_hidden_edges` into the intermediate `Box3D`
- emit namespaced `extras.poppygl.showHiddenEdges` on every glTF node path
- test the complete Circuit JSON → scene → glTF propagation

## Why

This is the bridge between the end-user enclosure prop and PoppyGL's hidden-edge renderer. The metadata is attached to the model node, so only the opted-in enclosure is affected.

## Dependency

- depends on tscircuit/circuit-json#695 for the canonical `show_hidden_edges` schema field
- compatible with older Circuit JSON type packages while that schema PR is pending

## Impact

No glTF output changes unless `show_hidden_edges` is true.

## Checks

- `bun test tests/unit`
- `bunx tsc --noEmit`
- `bun run build`
- targeted Biome formatting/check